### PR TITLE
removed neutral items that are cycled out in 7.28

### DIFF
--- a/game/scripts/npc/neutral_items.txt
+++ b/game/scripts/npc/neutral_items.txt
@@ -19,7 +19,6 @@
 			"item_keen_optic"				  "1"
 			"item_broom_handle"				  "1"
 			"item_faded_broach"				  "1"
-			"item_poor_mans_shield"			  "1"
 			"item_mysterious_hat"			  "1"
 			"item_possessed_mask"			  "1"
 		}
@@ -39,9 +38,7 @@
 
 		"items"
 		{
-			"item_mango_tree"				  "1"
 			"item_royal_jelly"				  "1"
-			"item_iron_talon"				  "1"
 			"item_arcane_ring"				  "1"
 			"item_ironwood_tree"			  "1"
 			"item_trusty_shovel"			  "1"
@@ -68,7 +65,6 @@
 			"item_nether_shawl"				  "1"
 			"item_imp_claw"					  "1"
 			"item_essence_ring"				  "1"
-			"item_vampire_fangs"			  "1"
 			"item_quicksilver_amulet"		  "1"
 		}
 	}
@@ -89,10 +85,8 @@
 		{
 			"item_pupils_gift"				  "1"
 			"item_dragon_scale"				  "1"
-			"item_clumsy_net"				  "1"
 			"item_ring_of_aquila"			  "1"
 			"item_vambrace"			 		  "1"
-			"item_repair_kit"				  "1"
 			"item_bullwhip"					  "1"
 		}
 	}
@@ -112,9 +106,7 @@
 		"items"
 		{
 			"item_quickening_charm"			  "1"
-			"item_greater_faerie_fire"		  "1"
 			"item_enchanted_quiver"			  "1"
-			"item_craggy_coat"				  "1"
 			"item_paladin_sword"			  "1"
 			"item_orb_of_destruction"		  "1"
 			"item_elven_tunic"		 		  "1"
@@ -160,12 +152,9 @@
 		"items"
 		{
 			"item_ninja_gear"				  "1"
-			"item_panic_button"				  "1"
 			"item_the_leveller"				  "1"
-			"item_witless_shako"			  "1"
-			"item_havoc_hammer"				  "1"
-			"item_princes_knife"			  "1"
 			"item_penta_edged_sword"		  "1"
+			"item_stormcrafter"				  "1"
 		}
 	}
 	"8"
@@ -183,13 +172,11 @@
 
 		"items"
 		{
-			"item_recipe_trident"			  "1"
 			"item_illusionsts_cape"			  "1"
 			"item_timeless_relic"			  "1"
 			"item_spell_prism"				  "1"
 			"item_flicker"					  "1"
 			"item_spy_gadget"				  "1"
-			"item_stormcrafter"				  "1"
 			"item_trickster_cloak"			  "1"
 		}
 	}
@@ -211,7 +198,6 @@
 			"item_seer_stone"				  "1"
 			"item_apex"						  "1"
 			"item_ballista"					  "1"
-			"item_woodland_striders"		  "1"
 			"item_book_of_shadows"		  	  "1"
 			"item_giants_ring"		 		  "1"
 		}


### PR DESCRIPTION
also moved stormcrafter to a lower tier because said tier is now severely lacking in neutral drop variety